### PR TITLE
:hammer: Fix minor typo in particles example

### DIFF
--- a/src/apps/particles.cpp
+++ b/src/apps/particles.cpp
@@ -129,8 +129,8 @@ main(int argc, char *argv[])
   if (nparticles == 1)
   {
     *p++ = (MM.x + mm.x) / 2.0;
-    *p++ = (MM.x + mm.x) / 2.0;
-    *p++ = (MM.x + mm.x) / 2.0;
+    *p++ = (MM.y + mm.y) / 2.0;
+    *p++ = (MM.z + mm.z) / 2.0;
     if (random_v)
       *p++ = frand();
     else


### PR DESCRIPTION
Hi @GregAbram noticed a very minor typo in the coordinates computation in the particles example. Thanks!